### PR TITLE
fix(ci): force changes.outputs.code=true on tag pushes so docker job runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,12 @@ jobs:
       contents: read
       pull-requests: read
     outputs:
-      code: ${{ steps.filter.outputs.code }}
+      # On tag pushes (`refs/tags/v*`) we ALWAYS run the full pipeline —
+      # otherwise dorny/paths-filter compares tag commit vs main HEAD and
+      # returns code=false when they're the same SHA, skipping the whole
+      # chain including `docker`. The `||` short-circuits to the filter
+      # result for non-tag events.
+      code: ${{ startsWith(github.ref, 'refs/tags/') && 'true' || steps.filter.outputs.code }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - id: filter


### PR DESCRIPTION
## Summary
- The tag-triggered run for v0.1.0 had `docker` (and every code-gated job) skipped: dorny/paths-filter compared the tag commit to main's HEAD, saw zero diff, emitted `code=false`, and the downstream `if: needs.changes.outputs.code == 'true'` skipped build/test/integration-test/e2e/docker — defeating the whole point of the tag push.
- The path filter is a doc-only-skip optimization meant for push and PR events on main. On tag pushes we always want the publish pipeline. Add a `startsWith(github.ref, 'refs/tags/') && 'true' || steps.filter.outputs.code` short-circuit on the changes output.
- After this PR merges, re-tag `v0.1.0` at the new HEAD to trigger a real `docker` job run with Trivy + smoke + multi-arch push + cosign signing.

## Test plan
- [x] make ci passes locally
- [ ] CI on this PR shows changes/static-check/build/test/integration-test/e2e green (no docker — not tag-gated for PR runs)
- [ ] After merge: delete and recreate v0.1.0 at the new main HEAD; verify docker job runs end-to-end