### PR TITLE
chore: align k8s manifests + Makefile with GHCR-published image refs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,8 +49,15 @@ KUBECTL           := kubectl --context $(KUBECTL_CTX)
 CURRENTTAG := $(shell git describe --tags --abbrev=0 2>/dev/null || echo v0.0.0)
 NEWTAG    ?=
 
-IMAGE_REPO_PREFIX ?= andriykalashnykov/dapr-go
-IMAGE_TAG         ?= v0.0.1
+# Match what `docker/metadata-action` publishes to GHCR — same path so the
+# manifest in k8s/apps/*.yaml resolves the same image whether it's loaded
+# into KinD locally (`make deploy-workloads` → `kind load docker-image`)
+# or pulled from the registry by a non-KinD deploy.
+IMAGE_REPO_PREFIX ?= ghcr.io/andriykalashnykov/dapr-go
+# Strip the `v` prefix from the latest git tag (metadata-action's
+# semver pattern emits 0.1.0 for tag v0.1.0). Falls back to 0.0.0 on a
+# fresh checkout with no tags.
+IMAGE_TAG         ?= $(shell git describe --tags --abbrev=0 2>/dev/null | sed 's/^v//' || echo 0.0.0)
 
 SERVICES := read-values subscriber write-values frontendsvc
 
@@ -200,7 +207,7 @@ image-build:
 		echo ">> image-build $$dir"; \
 		(cd "$$dir" && DOCKER_BUILDKIT=1 docker buildx build --load \
 			--platform linux/amd64 \
-			-t $(IMAGE_REPO_PREFIX)-$$svc:$(IMAGE_TAG) .); \
+			-t $(IMAGE_REPO_PREFIX)/$$svc:$(IMAGE_TAG) .); \
 	done
 
 #image-push: @ Build and push multi-arch images (linux/amd64,linux/arm64) to the registry
@@ -211,7 +218,7 @@ image-push:
 		(cd "$$dir" && DOCKER_BUILDKIT=1 docker buildx build --push \
 			--platform linux/amd64,linux/arm64 \
 			--provenance=false --sbom=false \
-			-t $(IMAGE_REPO_PREFIX)-$$svc:$(IMAGE_TAG) .); \
+			-t $(IMAGE_REPO_PREFIX)/$$svc:$(IMAGE_TAG) .); \
 	done
 
 # ---------------------------------------------------------------------------

--- a/k8s/apps/apps.yaml
+++ b/k8s/apps/apps.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
         - name: read-values
-          image: andriykalashnykov/dapr-go-read-values:v0.0.1
+          image: ghcr.io/andriykalashnykov/dapr-go/read-values:0.1.0
           env:
             - name: DAPR_PORT
               value: "50001"
@@ -64,7 +64,7 @@ spec:
     spec:
       containers:
         - name: subscriber
-          image: andriykalashnykov/dapr-go-subscriber:v0.0.1
+          image: ghcr.io/andriykalashnykov/dapr-go/subscriber:0.1.0
           resources:
             limits:
               memory: "128Mi"
@@ -106,7 +106,7 @@ spec:
     spec:
       containers:
         - name: write-values
-          image: andriykalashnykov/dapr-go-write-values:v0.0.1
+          image: ghcr.io/andriykalashnykov/dapr-go/write-values:0.1.0
           env:
             - name: DAPR_PORT
               value: "50001"

--- a/k8s/apps/frontend.yaml
+++ b/k8s/apps/frontend.yaml
@@ -21,7 +21,7 @@ spec:
     spec:
       containers:
         - name: frontendsvc
-          image: andriykalashnykov/dapr-go-frontendsvc:v0.0.1
+          image: ghcr.io/andriykalashnykov/dapr-go/frontendsvc:0.1.0
           ports:
             - containerPort: 8080
           env:

--- a/scripts/workloads.sh
+++ b/scripts/workloads.sh
@@ -8,8 +8,12 @@ SCRIPT_PARENT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
 # shellcheck source=env.sh
 . "${SCRIPT_DIR}/env.sh"
 
-IMAGE_TAG="${IMAGE_TAG:-v0.0.1}"
-IMAGE_REPO_PREFIX="${IMAGE_REPO_PREFIX:-andriykalashnykov/dapr-go}"
+# Defaults match the Makefile (and the GHCR path metadata-action publishes
+# to). The Makefile derives IMAGE_TAG from `git describe --tags --abbrev=0`
+# stripped of the v prefix, so a local checkout at tag v0.1.0 builds
+# `ghcr.io/.../svc:0.1.0` — which is exactly what k8s/apps/*.yaml references.
+IMAGE_TAG="${IMAGE_TAG:-0.0.0}"
+IMAGE_REPO_PREFIX="${IMAGE_REPO_PREFIX:-ghcr.io/andriykalashnykov/dapr-go}"
 SERVICES=(read-values subscriber write-values frontendsvc)
 
 SCRIPT_ACTION="${1:-deploy}"
@@ -24,7 +28,7 @@ case "${SCRIPT_ACTION}" in
   deploy)
     for svc in "${SERVICES[@]}"; do
       kind load docker-image \
-        "${IMAGE_REPO_PREFIX}-${svc}:${IMAGE_TAG}" \
+        "${IMAGE_REPO_PREFIX}/${svc}:${IMAGE_TAG}" \
         --name "${KIND_CLUSTER_NAME}"
     done
 


### PR DESCRIPTION
## Summary
- After the `v0.1.0` docker job published all four service images to `ghcr.io/andriykalashnykov/dapr-go/<svc>:0.1.0` (cosign keyless signed, multi-arch), align the consumers to the same path.
- `k8s/apps/apps.yaml` + `frontend.yaml` now reference `ghcr.io/andriykalashnykov/dapr-go/<svc>:0.1.0` — `kubectl apply` pulls the published, signed images directly.
- `Makefile`: `IMAGE_REPO_PREFIX` switched to `ghcr.io/andriykalashnykov/dapr-go`; `IMAGE_TAG` derived from `git describe --tags --abbrev=0 | sed 's/^v//'` so local builds at tag `vX.Y.Z` produce images at `:X.Y.Z` (matching `metadata-action`'s `type=semver`). Recipe uses `/` not `-` between prefix and svc.
- `scripts/workloads.sh`: matching `/`-separator + v-stripped defaults so `kind load docker-image` aligns with the manifest's image path.

## Test plan
- [x] `make image-build` produces `ghcr.io/andriykalashnykov/dapr-go/<svc>:0.1.0` (verified locally)
- [x] `docker buildx imagetools inspect ghcr.io/andriykalashnykov/dapr-go/<svc>:0.1.0` shows `linux/amd64` + `linux/arm64`, zero `unknown/unknown` entries (all 4 services)
- [x] `cosign verify ghcr.io/andriykalashnykov/dapr-go/<svc>:0.1.0` succeeds for all 4 services (4 signatures per image: tags 0.1.0, 0.1, 0, latest)
- [ ] CI on this PR: green; docker job correctly skipped (PR isn't a tag push)
- [ ] After merge: a fresh `make kind-deploy` from a clean checkout against tag `v0.1.0` should successfully deploy all four services using the GHCR-named local images