### PR TITLE
chore(renovate): switch .mise.toml to native mise manager, drop duplicate regex

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -1,17 +1,11 @@
 [tools]
-# renovate: datasource=github-tags depName=go extractVersion=^go(?<version>.+)$
+# Versions tracked by Renovate's native `mise` manager (see renovate.json
+# enabledManagers). The manager queries github-tags/github-releases/
+# golang-version per backend; no inline `# renovate:` annotations needed.
 go = "1.26.2"
-
-# renovate: datasource=github-releases depName=kubernetes-sigs/kind
 kind = "0.27.0"
-
-# renovate: datasource=github-releases depName=kubernetes/kubectl extractVersion=^v(?<version>.+)$
 kubectl = "1.34.0"
-
-# renovate: datasource=github-releases depName=helm/helm
 helm = "3.18.0"
-
-# renovate: datasource=github-releases depName=dapr/cli
 "aqua:dapr/cli" = "1.15.1"
 
 [settings]

--- a/renovate.json
+++ b/renovate.json
@@ -4,7 +4,7 @@
     "config:best-practices",
     ":semanticCommitType(chore)"
   ],
-  "enabledManagers": ["gomod", "github-actions", "dockerfile", "kubernetes", "custom.regex"],
+  "enabledManagers": ["gomod", "github-actions", "dockerfile", "kubernetes", "mise", "custom.regex"],
   "kubernetes": {
     "managerFilePatterns": ["/^k8s/.+\\.yaml$/"]
   },
@@ -27,14 +27,6 @@
       "managerFilePatterns": ["/^Makefile$/"],
       "matchStrings": [
         "# renovate: datasource=(?<datasource>[^\\s]+) depName=(?<depName>[^\\s]+)( versioning=(?<versioning>[^\\s]+))?\\n[A-Z_]+\\s*:=\\s*(?<currentValue>[^\\s]+)"
-      ]
-    },
-    {
-      "customType": "regex",
-      "description": "Update .mise.toml tool pins via inline renovate comments",
-      "managerFilePatterns": ["/^\\.mise\\.toml$/"],
-      "matchStrings": [
-        "# renovate: datasource=(?<datasource>[^\\s]+) depName=(?<depName>[^\\s]+)( extractVersion=(?<extractVersion>[^\\s]+))?( versioning=(?<versioning>[^\\s]+))?\\n[a-zA-Z_-]+\\s*=\\s*\"(?<currentValue>[^\"]+)\""
       ]
     }
   ],


### PR DESCRIPTION
## Summary
- Per the /renovate skill update (2026-05-06), the canonical pattern is to use Renovate's native `mise` manager for `.mise.toml` instead of a `custom.regex` over inline `# renovate:` comments.
- Native manager queries proper datasources per backend (github-tags for `aqua:`, golang-version for `go`, github-releases for kind/kubectl/helm) — better extraction than generic regex parsing, and avoids the duplicate-PR-per-bump trap when two managers cover the same file.
- The Makefile `custom.regex` stays — it covers `_VERSION` constants the native manager doesn't see.

## Test plan
- [x] `npx renovate --platform=local` validates clean (no `validationError`)
- [x] Manager stats: `mise: 1 file, 5 deps; regex: 1 file, 8 deps` (was `regex: 12 deps` with duplicates)
- [x] Total deps tracked across all managers: 265
- [ ] CI on this PR: green